### PR TITLE
Fixed login/reg styling issue for Login splashTitle

### DIFF
--- a/client/src/component/LoginReg.css
+++ b/client/src/component/LoginReg.css
@@ -35,7 +35,7 @@ body{
 }
 
 .splashTextTitle{
-  text-align: center;
+  text-align: center !important;
   color: lightgoldenrodyellow;
   text-shadow: 0px 0px 2px lightgoldenrodyellow;
   font-size: 50px;


### PR DESCRIPTION
It was left-aligned, should be center-aligned. No other changes.